### PR TITLE
Fix grep command

### DIFF
--- a/git-commands.js
+++ b/git-commands.js
@@ -5,7 +5,7 @@ module.exports = {
    * Returns latest tag, sorted by version or null if no tag was found
    */
   getLatestTag: (prefix) => {
-    const maybeGrepCommand = prefix !== '' ? `| grep "${prefix}*"` : '';
+    const maybeGrepCommand = prefix !== '' ? `| grep "^${prefix}"` : '';
     const stdout = exec(`git tag -l ${maybeGrepCommand} | sort -V | tail -n 1`);
     const lastTag = String(stdout).trim();
     return lastTag === '' ? null : lastTag;


### PR DESCRIPTION
Get only tags starting with prefix instead of tags including first n-1 letters of prefix + any number of last letter in prefix
For example `v*` means every single tag (tag that has 0 or more "v" in it)