### PR TITLE
Bump required NodeJS to version 16.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js 12.x
-        uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 16
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
       - run: npm test -- --coverage
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 16
           cache: 'npm'
       - name: build on branch
         run: |

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ outputs:
     description: "next version without prefix"
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 
 branding:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "next-version",
       "dependencies": {
         "@actions/core": "^1.6.0",
         "@gh-stats/reporter": "^1.0.6",


### PR DESCRIPTION
# What
Update workflows to current versions
Update required NodeJS version to 16

# Why
Syncs node version to the one used by stock GitHub Actions and
updates unsupported CodeCov action.